### PR TITLE
Fix bugs for mailbox/cassandra

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraACLDAOV1.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraACLDAOV1.java
@@ -71,13 +71,13 @@ public class CassandraACLDAOV1 {
     @Inject
     public CassandraACLDAOV1(CqlSession session,
                              CassandraConfiguration cassandraConfiguration) {
+        this.session = session;
         this.executor = new CassandraAsyncExecutor(session);
         this.maxAclRetry = cassandraConfiguration.getAclMaxRetry();
         this.conditionalInsertStatement = prepareConditionalInsert();
         this.conditionalUpdateStatement = prepareConditionalUpdate();
         this.readStatement = prepareReadStatement();
         this.deleteStatement = prepareDelete();
-        this.session = session;
         this.lwtProfile = JamesExecutionProfiles.getLWTProfile(session);
     }
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraACLDAOV2.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraACLDAOV2.java
@@ -68,7 +68,7 @@ public class CassandraACLDAOV2 {
 
     private PreparedStatement prepareInsertRights(CqlSession session) {
         return session.prepare(update(CassandraACLV2Table.TABLE_NAME)
-            .appendSetElement(CassandraACLV2Table.RIGHTS, bindMarker(CassandraACLV2Table.RIGHTS))
+            .append(CassandraACLV2Table.RIGHTS, bindMarker(CassandraACLV2Table.RIGHTS))
             .where(column(CassandraACLV2Table.ID).isEqualTo(bindMarker(CassandraACLV2Table.ID)),
                 column(CassandraACLV2Table.KEY).isEqualTo(bindMarker(CassandraACLV2Table.KEY)))
             .build());
@@ -84,7 +84,7 @@ public class CassandraACLDAOV2 {
 
     private PreparedStatement prepareRemoveRights(CqlSession session) {
         return session.prepare(update(CassandraACLV2Table.TABLE_NAME)
-            .removeSetElement(CassandraACLV2Table.RIGHTS, bindMarker(CassandraACLV2Table.RIGHTS))
+            .remove(CassandraACLV2Table.RIGHTS, bindMarker(CassandraACLV2Table.RIGHTS))
             .where(column(CassandraACLV2Table.ID).isEqualTo(bindMarker(CassandraACLV2Table.ID)),
                 column(CassandraACLV2Table.KEY).isEqualTo(bindMarker(CassandraACLV2Table.KEY)))
             .build());

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraApplicableFlagDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraApplicableFlagDAO.java
@@ -71,7 +71,7 @@ public class CassandraApplicableFlagDAO {
 
     private PreparedStatement prepareUpdate(CqlSession session) {
         return session.prepare(QueryBuilder.update(TABLE_NAME)
-            .appendSetElement(USER_FLAGS, bindMarker(USER_FLAGS))
+            .append(USER_FLAGS, bindMarker(USER_FLAGS))
             .where(column(MAILBOX_ID).isEqualTo(bindMarker(MAILBOX_ID)))
             .build());
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2.java
@@ -152,15 +152,14 @@ public class CassandraAttachmentDAOV2 {
 
     @Inject
     public CassandraAttachmentDAOV2(BlobId.Factory blobIdFactory, CqlSession session) {
+        this.session = session;
         this.blobIdFactory = blobIdFactory;
         this.cassandraAsyncExecutor = new CassandraAsyncExecutor(session);
-
         this.selectStatement = prepareSelect();
         this.insertStatement = prepareInsert();
         this.deleteStatement = prepareDelete();
         this.listBlobs = prepareSelectBlobs();
         this.insertMessageIdStatement = prepareInsertMessageId();
-        this.session = session;
     }
 
     private PreparedStatement prepareSelectBlobs() {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxDAO.java
@@ -70,6 +70,7 @@ public class CassandraMailboxDAO {
 
     @Inject
     public CassandraMailboxDAO(CqlSession session, CassandraTypesProvider typesProvider) {
+        this.session = session;
         this.executor = new CassandraAsyncExecutor(session);
         this.mailboxBaseTupleUtil = new MailboxBaseTupleUtil(typesProvider);
         this.insertStatement = prepareInsert();
@@ -78,7 +79,6 @@ public class CassandraMailboxDAO {
         this.deleteStatement = prepareDelete();
         this.listStatement = prepareList();
         this.readStatement = prepareRead();
-        this.session = session;
         this.lwtProfile = JamesExecutionProfiles.getLWTProfile(session);
     }
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3.java
@@ -28,7 +28,7 @@ import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.deleteFrom;
 import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom;
 import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.update;
 import static com.datastax.oss.driver.api.querybuilder.relation.Relation.column;
-import static com.datastax.oss.driver.api.querybuilder.update.Assignment.prependListElement;
+import static com.datastax.oss.driver.api.querybuilder.update.Assignment.prepend;
 import static com.datastax.oss.driver.api.querybuilder.update.Assignment.setColumn;
 import static org.apache.james.blob.api.BlobStore.StoragePolicy.LOW_COST;
 import static org.apache.james.blob.api.BlobStore.StoragePolicy.SIZE_BASED;
@@ -172,7 +172,7 @@ public class CassandraMessageDAOV3 {
                 setColumn(CONTENT_DISPOSITION_PARAMETERS, bindMarker(CONTENT_DISPOSITION_PARAMETERS)),
                 setColumn(CONTENT_TYPE_PARAMETERS, bindMarker(CONTENT_TYPE_PARAMETERS)),
                 setColumn(TEXTUAL_LINE_COUNT, bindMarker(TEXTUAL_LINE_COUNT)),
-                prependListElement(ATTACHMENTS, bindMarker(ATTACHMENTS)))
+                prepend(ATTACHMENTS, bindMarker(ATTACHMENTS)))
             .where(column(MESSAGE_ID).isEqualTo(bindMarker(MESSAGE_ID)))
             .build());
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAO.java
@@ -23,8 +23,8 @@ import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.deleteFrom;
 import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.update;
 import static com.datastax.oss.driver.api.querybuilder.relation.Relation.column;
-import static com.datastax.oss.driver.api.querybuilder.update.Assignment.appendSetElement;
-import static com.datastax.oss.driver.api.querybuilder.update.Assignment.removeSetElement;
+import static com.datastax.oss.driver.api.querybuilder.update.Assignment.append;
+import static com.datastax.oss.driver.api.querybuilder.update.Assignment.remove;
 import static com.datastax.oss.driver.api.querybuilder.update.Assignment.setColumn;
 import static org.apache.james.mailbox.cassandra.table.CassandraMessageIdTable.TABLE_NAME;
 import static org.apache.james.mailbox.cassandra.table.CassandraMessageIdTable.THREAD_ID;
@@ -160,7 +160,7 @@ public class CassandraMessageIdDAO {
                 setColumn(BODY_START_OCTET, bindMarker(BODY_START_OCTET)),
                 setColumn(FULL_CONTENT_OCTETS, bindMarker(FULL_CONTENT_OCTETS)),
                 setColumn(HEADER_CONTENT, bindMarker(HEADER_CONTENT)),
-                appendSetElement(USER_FLAGS, bindMarker(USER_FLAGS)))
+                append(USER_FLAGS, bindMarker(USER_FLAGS)))
             .where(column(MAILBOX_ID).isEqualTo(bindMarker(MAILBOX_ID)),
                 column(IMAP_UID).isEqualTo(bindMarker(IMAP_UID)))
             .build());
@@ -176,8 +176,8 @@ public class CassandraMessageIdDAO {
                 setColumn(RECENT, bindMarker(RECENT)),
                 setColumn(SEEN, bindMarker(SEEN)),
                 setColumn(USER, bindMarker(USER)),
-                appendSetElement(USER_FLAGS, bindMarker(ADDED_USERS_FLAGS)),
-                removeSetElement(USER_FLAGS, bindMarker(REMOVED_USERS_FLAGS)))
+                append(USER_FLAGS, bindMarker(ADDED_USERS_FLAGS)),
+                remove(USER_FLAGS, bindMarker(REMOVED_USERS_FLAGS)))
             .where(column(MAILBOX_ID).isEqualTo(bindMarker(MAILBOX_ID)),
                 column(IMAP_UID).isEqualTo(bindMarker(IMAP_UID)))
             .build());

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdToImapUidDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdToImapUidDAO.java
@@ -114,6 +114,7 @@ public class CassandraMessageIdToImapUidDAO {
     @Inject
     public CassandraMessageIdToImapUidDAO(CqlSession session, BlobId.Factory blobIdFactory,
                                           CassandraConfiguration cassandraConfiguration) {
+        this.session = session;
         this.cassandraAsyncExecutor = new CassandraAsyncExecutor(session);
         this.blobIdFactory = blobIdFactory;
         this.cassandraConfiguration = cassandraConfiguration;
@@ -124,7 +125,6 @@ public class CassandraMessageIdToImapUidDAO {
         this.selectAll = prepareSelectAll();
         this.select = prepareSelect();
         this.listStatement = prepareList();
-        this.session = session;
         this.lwtProfile = JamesExecutionProfiles.getLWTProfile(session);
     }
 
@@ -171,7 +171,7 @@ public class CassandraMessageIdToImapUidDAO {
                     setColumn(BODY_START_OCTET, bindMarker(BODY_START_OCTET)),
                     setColumn(FULL_CONTENT_OCTETS, bindMarker(FULL_CONTENT_OCTETS)),
                     setColumn(HEADER_CONTENT, bindMarker(HEADER_CONTENT)))
-                .appendSetElement(USER_FLAGS, bindMarker(USER_FLAGS))
+                .append(USER_FLAGS, bindMarker(USER_FLAGS))
                 .where(column(MESSAGE_ID).isEqualTo(bindMarker(MESSAGE_ID)),
                     column(MAILBOX_ID).isEqualTo(bindMarker(MAILBOX_ID)),
                     column(IMAP_UID).isEqualTo(bindMarker(IMAP_UID)))
@@ -210,8 +210,8 @@ public class CassandraMessageIdToImapUidDAO {
                 setColumn(RECENT, bindMarker(RECENT)),
                 setColumn(SEEN, bindMarker(SEEN)),
                 setColumn(USER, bindMarker(USER)))
-            .appendSetElement(USER_FLAGS, bindMarker(ADDED_USERS_FLAGS))
-            .removeSetElement(USER_FLAGS, bindMarker(REMOVED_USERS_FLAGS))
+            .append(USER_FLAGS, bindMarker(ADDED_USERS_FLAGS))
+            .remove(USER_FLAGS, bindMarker(REMOVED_USERS_FLAGS))
             .where(column(MESSAGE_ID).isEqualTo(bindMarker(MESSAGE_ID)),
                 column(MAILBOX_ID).isEqualTo(bindMarker(MAILBOX_ID)),
                 column(IMAP_UID).isEqualTo(bindMarker(IMAP_UID)));

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraMessageModule.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraMessageModule.java
@@ -106,8 +106,8 @@ public interface CassandraMessageModule {
             .withColumn(CassandraMessageV2Table.FULL_CONTENT_OCTETS, BIGINT)
             .withColumn(CassandraMessageV2Table.BODY_CONTENT, TEXT)
             .withColumn(CassandraMessageV2Table.HEADER_CONTENT, TEXT)
-            .withColumn(CassandraMessageV2Table.ATTACHMENTS, listOf(types.getDefinedUserType(CassandraMessageV2Table.ATTACHMENTS)))
-            .withColumn(CassandraMessageV2Table.PROPERTIES, listOf(types.getDefinedUserType(CassandraMessageV2Table.PROPERTIES))))
+            .withColumn(CassandraMessageV2Table.ATTACHMENTS, listOf(SchemaBuilder.udt(CassandraMessageV2Table.ATTACHMENTS, true)))
+            .withColumn(CassandraMessageV2Table.PROPERTIES, listOf(SchemaBuilder.udt(CassandraMessageV2Table.PROPERTIES, true))))
         .table(CassandraMessageV3Table.TABLE_NAME)
         .comment("Holds message metadata, independently of any mailboxes. Content of messages is stored " +
             "in `blobs` and `blobparts` tables. Optimizes property storage compared to V2.")
@@ -131,7 +131,7 @@ public interface CassandraMessageModule {
             .withColumn(CassandraMessageV3Table.Properties.CONTENT_LANGUAGE, frozenListOf(TEXT))
             .withColumn(CassandraMessageV3Table.Properties.CONTENT_DISPOSITION_PARAMETERS, frozenMapOf(TEXT, TEXT))
             .withColumn(CassandraMessageV3Table.Properties.CONTENT_TYPE_PARAMETERS, frozenMapOf(TEXT, TEXT))
-            .withColumn(CassandraMessageV3Table.ATTACHMENTS, listOf(types.getDefinedUserType(CassandraMessageV3Table.ATTACHMENTS))))
+            .withColumn(CassandraMessageV3Table.ATTACHMENTS, listOf(SchemaBuilder.udt(CassandraMessageV3Table.ATTACHMENTS, true))))
         .type(CassandraMessageV2Table.PROPERTIES)
         .statement(statement -> statement
             .withField(CassandraMessageV2Table.Properties.NAMESPACE, TEXT)


### PR DESCRIPTION
Debugging failing setFlags tests in `CassandraMessageIdMapperRelaxedConsistencyTest`, other thoughts on this may help.

The cause I think come from `imapUidDAO.updateMetadata` and `messageIdDAO.updateMetadata` when being called from `CassandraMessageIdMapper` throws error `Method threw 'com.datastax.oss.driver.api.core.DriverTimeoutException' exception. Query timed out after PT2S`.

Some notes may help:
-  `PT2S` means default 2 seconds timeout. I tried to set timeout to a big number but the query seems never ends.
-  Meanwhile `imapUidDAO.updateMetadata`/`messageIdDAO.updateMetadata`  when being called from `CassandraMessageIdToImapUidDAOTest` /`CassandraMessageIdDAOTest` succeeded within 2 seconds.
- I tried to switch `CassandraMessageIdMapperRelaxedConsistencyTest` to the same consistency configuration with `CassandraMessageIdToImapUidDAOTest` (CassandraConfiguration.DEFAULT_CONFIGURATION) but not help.